### PR TITLE
upgrade to embedded-hal 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-embedded-hal = "0.2.7"
+embedded-hal = "1.0.0"
 fixedvec = "0.2.4"

--- a/src/bmi270.rs
+++ b/src/bmi270.rs
@@ -34,46 +34,46 @@ impl<I2C> Bmi270<I2cInterface<I2C>> {
     }
 }
 
-impl<SPI, CS> Bmi270<SpiInterface<SPI, CS>> {
+impl<SPI> Bmi270<SpiInterface<SPI>> {
     /// Create a new Bmi270 device with SPI communication.
-    pub fn new_spi(spi: SPI, cs: CS, burst: Burst) -> Self {
+    pub fn new_spi(spi: SPI, burst: Burst) -> Self {
         Bmi270 {
-            iface: SpiInterface { spi, cs },
+            iface: SpiInterface { spi },
             max_burst: burst.val(),
         }
     }
 
     /// Release I2C and CS.
-    pub fn release(self) -> (SPI, CS) {
-        (self.iface.spi, self.iface.cs)
+    pub fn release(self) -> SPI {
+        self.iface.spi
     }
 }
 
-impl<I, CommE, CsE> Bmi270<I>
+impl<I, CommE> Bmi270<I>
 where
-    I: ReadData<Error = Error<CommE, CsE>> + WriteData<Error = Error<CommE, CsE>>,
+    I: ReadData<Error = Error<CommE>> + WriteData<Error = Error<CommE>>,
 {
     /// Get the chip id.
-    pub fn get_chip_id(&mut self) -> Result<u8, Error<CommE, CsE>> {
+    pub fn get_chip_id(&mut self) -> Result<u8, Error<CommE>> {
         self.iface.read_reg(Registers::CHIP_ID)
     }
 
     /// Get the errors from the error register.
-    pub fn get_errors(&mut self) -> Result<ErrorReg, Error<CommE, CsE>> {
+    pub fn get_errors(&mut self) -> Result<ErrorReg, Error<CommE>> {
         let errors = self.iface.read_reg(Registers::ERR_REG)?;
 
         Ok(ErrorReg::from_reg(errors))
     }
 
     /// Get the sensor status.
-    pub fn get_status(&mut self) -> Result<Status, Error<CommE, CsE>> {
+    pub fn get_status(&mut self) -> Result<Status, Error<CommE>> {
         let status = self.iface.read_reg(Registers::STATUS)?;
 
         Ok(Status::from_reg(status))
     }
 
     /// Get the sensor auxiliary data.
-    pub fn get_aux_data(&mut self) -> Result<AuxData, Error<CommE, CsE>> {
+    pub fn get_aux_data(&mut self) -> Result<AuxData, Error<CommE>> {
         let mut payload = [0_u8; 9];
         payload[0] = Registers::AUX_DATA_0;
         self.iface.read(&mut payload)?;
@@ -85,7 +85,7 @@ where
     }
 
     /// Get the sensor accelerometer data.
-    pub fn get_acc_data(&mut self) -> Result<AxisData, Error<CommE, CsE>> {
+    pub fn get_acc_data(&mut self) -> Result<AxisData, Error<CommE>> {
         let mut payload = [0_u8; 7];
         payload[0] = Registers::ACC_DATA_0;
         self.iface.read(&mut payload)?;
@@ -94,7 +94,7 @@ where
     }
 
     /// Get the sensor gyroscope data.
-    pub fn get_gyr_data(&mut self) -> Result<AxisData, Error<CommE, CsE>> {
+    pub fn get_gyr_data(&mut self) -> Result<AxisData, Error<CommE>> {
         let mut payload = [0_u8; 7];
         payload[0] = Registers::GYR_DATA_0;
         self.iface.read(&mut payload)?;
@@ -103,7 +103,7 @@ where
     }
 
     /// Get the sensor time.
-    pub fn get_sensor_time(&mut self) -> Result<u32, Error<CommE, CsE>> {
+    pub fn get_sensor_time(&mut self) -> Result<u32, Error<CommE>> {
         let mut payload = [Registers::SENSORTIME_0, 0, 0, 0];
         self.iface.read(&mut payload)?;
 
@@ -111,7 +111,7 @@ where
     }
 
     /// Get all the sensor data (excluding auxiliary data).
-    pub fn get_data(&mut self) -> Result<Data, Error<CommE, CsE>> {
+    pub fn get_data(&mut self) -> Result<Data, Error<CommE>> {
         let mut payload = [0_u8; 16];
         payload[0] = Registers::ACC_DATA_0;
         self.iface.read(&mut payload)?;
@@ -124,14 +124,14 @@ where
     }
 
     /// Get the event register.
-    pub fn get_event(&mut self) -> Result<Event, Error<CommE, CsE>> {
+    pub fn get_event(&mut self) -> Result<Event, Error<CommE>> {
         let event = self.iface.read_reg(Registers::EVENT)?;
 
         Ok(Event::from_reg(event))
     }
 
     /// Get the interrupt/feature status.
-    pub fn get_int_status(&mut self) -> Result<InterruptStatus, Error<CommE, CsE>> {
+    pub fn get_int_status(&mut self) -> Result<InterruptStatus, Error<CommE>> {
         let int_stat_0 = self.iface.read_reg(Registers::INT_STATUS_0)?;
         let int_stat_1 = self.iface.read_reg(Registers::INT_STATUS_1)?;
 
@@ -139,7 +139,7 @@ where
     }
 
     /// Get the step count.
-    pub fn get_step_count(&mut self) -> Result<u16, Error<CommE, CsE>> {
+    pub fn get_step_count(&mut self) -> Result<u16, Error<CommE>> {
         let mut payload = [Registers::SC_OUT_0, 0, 0];
         self.iface.read(&mut payload)?;
 
@@ -151,21 +151,21 @@ where
     /// Get the detected wrist gesture and activity type.
     pub fn get_wrist_gesture_activity(
         &mut self,
-    ) -> Result<WristGestureActivity, Error<CommE, CsE>> {
+    ) -> Result<WristGestureActivity, Error<CommE>> {
         let wr_gest_acc = self.iface.read_reg(Registers::WR_GEST_ACT)?;
 
         Ok(WristGestureActivity::from_reg(wr_gest_acc))
     }
 
     /// Get the sensor internal status.
-    pub fn get_internal_status(&mut self) -> Result<InternalStatus, Error<CommE, CsE>> {
+    pub fn get_internal_status(&mut self) -> Result<InternalStatus, Error<CommE>> {
         let internal_status = self.iface.read_reg(Registers::INTERNAL_STATUS)?;
 
         Ok(InternalStatus::from_reg(internal_status))
     }
 
     /// Get the sensor temperature.
-    pub fn get_temperature(&mut self) -> Result<Option<f32>, Error<CommE, CsE>> {
+    pub fn get_temperature(&mut self) -> Result<Option<f32>, Error<CommE>> {
         let mut payload = [Registers::TEMPERATURE_0, 0, 0];
         self.iface.read(&mut payload)?;
         let raw_temp = u16::from(payload[1]) | u16::from(payload[2]) << 8;
@@ -177,7 +177,7 @@ where
     }
 
     /// Get the current fill level of the FIFO buffer.
-    pub fn get_fifo_len(&mut self) -> Result<i16, Error<CommE, CsE>> {
+    pub fn get_fifo_len(&mut self) -> Result<i16, Error<CommE>> {
         let mut payload = [Registers::FIFO_LENGTH_0, 0, 0];
         self.iface.read(&mut payload)?;
         let len = i16::from(payload[1]) | i16::from(payload[2] & FIFO_LENGTH_1_MASK) << 8;
@@ -185,98 +185,98 @@ where
         Ok(len)
     }
 
-    pub fn get_fifo_data(&mut self) -> Result<(), Error<CommE, CsE>> {
+    pub fn get_fifo_data(&mut self) -> Result<(), Error<CommE>> {
         // TODO Fifo is 6KB, will need the max read info from user + fifo config
         Ok(())
     }
 
     /// Get the accelerometer configuration.
-    pub fn get_acc_conf(&mut self) -> Result<AccConf, Error<CommE, CsE>> {
+    pub fn get_acc_conf(&mut self) -> Result<AccConf, Error<CommE>> {
         let acc_conf = self.iface.read_reg(Registers::ACC_CONF)?;
         Ok(AccConf::from_reg(acc_conf))
     }
 
     /// Set the accelerometer configuration.
-    pub fn set_acc_conf(&mut self, acc_conf: AccConf) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_acc_conf(&mut self, acc_conf: AccConf) -> Result<(), Error<CommE>> {
         let reg = acc_conf.to_reg();
         self.iface.write_reg(Registers::ACC_CONF, reg)?;
         Ok(())
     }
 
     /// Get the accelerometer range.
-    pub fn get_acc_range(&mut self) -> Result<AccRange, Error<CommE, CsE>> {
+    pub fn get_acc_range(&mut self) -> Result<AccRange, Error<CommE>> {
         let acc_range = self.iface.read_reg(Registers::ACC_RANGE)?;
         Ok(AccRange::from_reg(acc_range))
     }
 
     /// Set the accelerometer range.
-    pub fn set_acc_range(&mut self, acc_range: AccRange) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_acc_range(&mut self, acc_range: AccRange) -> Result<(), Error<CommE>> {
         self.iface
             .write_reg(Registers::ACC_RANGE, acc_range as u8)?;
         Ok(())
     }
 
     /// Get the gyroscope configuration.
-    pub fn get_gyr_conf(&mut self) -> Result<GyrConf, Error<CommE, CsE>> {
+    pub fn get_gyr_conf(&mut self) -> Result<GyrConf, Error<CommE>> {
         let gyr_conf = self.iface.read_reg(Registers::GYR_CONF)?;
         Ok(GyrConf::from_reg(gyr_conf))
     }
 
     /// Set the gyroscope configuration.
-    pub fn set_gyr_conf(&mut self, gyr_conf: GyrConf) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_gyr_conf(&mut self, gyr_conf: GyrConf) -> Result<(), Error<CommE>> {
         let reg = gyr_conf.to_reg();
         self.iface.write_reg(Registers::GYR_CONF, reg)?;
         Ok(())
     }
 
     /// Get the gyroscope range.
-    pub fn get_gyr_range(&mut self) -> Result<GyrRange, Error<CommE, CsE>> {
+    pub fn get_gyr_range(&mut self) -> Result<GyrRange, Error<CommE>> {
         let gyr_range = self.iface.read_reg(Registers::GYR_RANGE)?;
         Ok(GyrRange::from_reg(gyr_range))
     }
 
     /// Set the gyroscope configuration.
-    pub fn set_gyr_range(&mut self, gyr_range: GyrRange) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_gyr_range(&mut self, gyr_range: GyrRange) -> Result<(), Error<CommE>> {
         let reg = gyr_range.to_reg();
         self.iface.write_reg(Registers::GYR_RANGE, reg)?;
         Ok(())
     }
 
     /// Get the Auxiliary device configuration.
-    pub fn get_aux_conf(&mut self) -> Result<AuxConf, Error<CommE, CsE>> {
+    pub fn get_aux_conf(&mut self) -> Result<AuxConf, Error<CommE>> {
         let aux_conf = self.iface.read_reg(Registers::AUX_CONF)?;
         Ok(AuxConf::from_reg(aux_conf))
     }
 
     /// Set the Auxiliary device configuration.
-    pub fn set_aux_conf(&mut self, aux_conf: AuxConf) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_aux_conf(&mut self, aux_conf: AuxConf) -> Result<(), Error<CommE>> {
         let reg = aux_conf.to_reg();
         self.iface.write_reg(Registers::AUX_CONF, reg)?;
         Ok(())
     }
 
     /// Get the fifo downsampling configuration.
-    pub fn get_fifo_downs(&mut self) -> Result<FifoDowns, Error<CommE, CsE>> {
+    pub fn get_fifo_downs(&mut self) -> Result<FifoDowns, Error<CommE>> {
         let fifo_downs = self.iface.read_reg(Registers::FIFO_DOWNS)?;
         Ok(FifoDowns::from_reg(fifo_downs))
     }
 
     /// Set the fifo downsampling configuration.
-    pub fn set_fifo_downs(&mut self, fifo_downs: FifoDowns) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_fifo_downs(&mut self, fifo_downs: FifoDowns) -> Result<(), Error<CommE>> {
         let reg = fifo_downs.to_reg();
         self.iface.write_reg(Registers::FIFO_DOWNS, reg)?;
         Ok(())
     }
 
     /// Get the fifo watermark level.
-    pub fn get_fifo_wtm(&mut self) -> Result<u16, Error<CommE, CsE>> {
+    pub fn get_fifo_wtm(&mut self) -> Result<u16, Error<CommE>> {
         let mut payload = [Registers::FIFO_WTM_0, 0, 0];
         self.iface.read(&mut payload)?;
         Ok(u16::from(payload[1]) | u16::from(payload[2]) << 8)
     }
 
     /// Set the fifo watermark level. Interrupt will trigger when the fifo reaches wtm * 256 bytes.
-    pub fn set_fifo_wtm(&mut self, wtm: u16) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_fifo_wtm(&mut self, wtm: u16) -> Result<(), Error<CommE>> {
         let reg_0 = wtm as u8;
         let reg_1 = (wtm >> 8) as u8;
         let mut payload = [Registers::FIFO_WTM_0, reg_0, reg_1];
@@ -285,14 +285,14 @@ where
     }
 
     /// Get the fifo configuration.
-    pub fn get_fifo_conf(&mut self) -> Result<FifoConf, Error<CommE, CsE>> {
+    pub fn get_fifo_conf(&mut self) -> Result<FifoConf, Error<CommE>> {
         let mut payload = [Registers::FIFO_CONFIG_0, 0, 0];
         self.iface.read(&mut payload)?;
         Ok(FifoConf::from_regs(payload[1], payload[2]))
     }
 
     /// Set the fifo configuration.
-    pub fn set_fifo_conf(&mut self, fifo_conf: FifoConf) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_fifo_conf(&mut self, fifo_conf: FifoConf) -> Result<(), Error<CommE>> {
         let (reg_0, reg_1) = fifo_conf.to_regs();
         let mut payload = [Registers::FIFO_CONFIG_0, reg_0, reg_1];
         self.iface.write(&mut payload)?;
@@ -300,127 +300,127 @@ where
     }
 
     /// Get the current saturation.
-    pub fn get_saturation(&mut self) -> Result<Saturation, Error<CommE, CsE>> {
+    pub fn get_saturation(&mut self) -> Result<Saturation, Error<CommE>> {
         let saturation = self.iface.read_reg(Registers::SATURATION)?;
         Ok(Saturation::from_reg(saturation))
     }
 
     /// Get the auxiliary device id.
-    pub fn get_aux_dev_id(&mut self) -> Result<u8, Error<CommE, CsE>> {
+    pub fn get_aux_dev_id(&mut self) -> Result<u8, Error<CommE>> {
         let dev_id = self.iface.read_reg(Registers::AUX_DEV_ID)?;
         Ok(dev_id >> 1)
     }
 
     /// Set the auxiliary device id.
-    pub fn set_aux_dev_id(&mut self, dev_id: u8) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_aux_dev_id(&mut self, dev_id: u8) -> Result<(), Error<CommE>> {
         let reg = dev_id << 1;
         self.iface.write_reg(Registers::AUX_DEV_ID, reg)?;
         Ok(())
     }
 
     /// Get auxiliary device interface configuration.
-    pub fn get_aux_if_conf(&mut self) -> Result<AuxIfConf, Error<CommE, CsE>> {
+    pub fn get_aux_if_conf(&mut self) -> Result<AuxIfConf, Error<CommE>> {
         let aux_if_conf = self.iface.read_reg(Registers::AUX_IF_CONF)?;
         Ok(AuxIfConf::from_reg(aux_if_conf))
     }
 
     /// Set auxiliary device interface configuration.
-    pub fn set_aux_if_conf(&mut self, aux_if_conf: AuxIfConf) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_aux_if_conf(&mut self, aux_if_conf: AuxIfConf) -> Result<(), Error<CommE>> {
         let reg = aux_if_conf.to_reg();
         self.iface.write_reg(Registers::AUX_IF_CONF, reg)?;
         Ok(())
     }
 
     /// Get auxiliary device read address.
-    pub fn get_aux_rd_addr(&mut self) -> Result<u8, Error<CommE, CsE>> {
+    pub fn get_aux_rd_addr(&mut self) -> Result<u8, Error<CommE>> {
         let aux_rd_addr = self.iface.read_reg(Registers::AUX_RD_ADDR)?;
         Ok(aux_rd_addr)
     }
 
     /// Set auxiliary device read address.
-    pub fn set_aux_rd_addr(&mut self, aux_rd_addr: u8) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_aux_rd_addr(&mut self, aux_rd_addr: u8) -> Result<(), Error<CommE>> {
         self.iface.write_reg(Registers::AUX_RD_ADDR, aux_rd_addr)?;
         Ok(())
     }
 
     /// Get auxiliary device write address.
-    pub fn get_aux_wr_addr(&mut self) -> Result<u8, Error<CommE, CsE>> {
+    pub fn get_aux_wr_addr(&mut self) -> Result<u8, Error<CommE>> {
         let aux_wr_addr = self.iface.read_reg(Registers::AUX_WR_ADDR)?;
         Ok(aux_wr_addr)
     }
 
     /// Set auxiliary device write address.
-    pub fn set_aux_wr_addr(&mut self, aux_wr_addr: u8) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_aux_wr_addr(&mut self, aux_wr_addr: u8) -> Result<(), Error<CommE>> {
         self.iface.write_reg(Registers::AUX_WR_ADDR, aux_wr_addr)?;
         Ok(())
     }
 
     /// Get auxiliary device data to write.
-    pub fn get_aux_wr_data(&mut self) -> Result<u8, Error<CommE, CsE>> {
+    pub fn get_aux_wr_data(&mut self) -> Result<u8, Error<CommE>> {
         let aux_wr_data = self.iface.read_reg(Registers::AUX_WR_DATA)?;
         Ok(aux_wr_data)
     }
 
     /// Set auxiliary device data to write.
-    pub fn set_aux_wr_data(&mut self, aux_wr_data: u8) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_aux_wr_data(&mut self, aux_wr_data: u8) -> Result<(), Error<CommE>> {
         self.iface.write_reg(Registers::AUX_WR_DATA, aux_wr_data)?;
         Ok(())
     }
 
     /// Get error register mask.
-    pub fn get_err_reg_msk(&mut self) -> Result<ErrorRegMsk, Error<CommE, CsE>> {
+    pub fn get_err_reg_msk(&mut self) -> Result<ErrorRegMsk, Error<CommE>> {
         let err_reg_msk = self.iface.read_reg(Registers::ERR_REG_MSK)?;
         Ok(ErrorRegMsk::from_reg(err_reg_msk))
     }
 
     /// Get error register mask.
-    pub fn set_err_reg_msk(&mut self, err_reg_msk: ErrorRegMsk) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_err_reg_msk(&mut self, err_reg_msk: ErrorRegMsk) -> Result<(), Error<CommE>> {
         let reg = err_reg_msk.to_reg();
         self.iface.write_reg(Registers::ERR_REG_MSK, reg)?;
         Ok(())
     }
 
     /// Get interrupt 1 io control.
-    pub fn get_int1_io_ctrl(&mut self) -> Result<IntIoCtrl, Error<CommE, CsE>> {
+    pub fn get_int1_io_ctrl(&mut self) -> Result<IntIoCtrl, Error<CommE>> {
         let int1_io_ctrl = self.iface.read_reg(Registers::INT1_IO_CTRL)?;
         Ok(IntIoCtrl::from_reg(int1_io_ctrl))
     }
 
     /// Set interrupt 1 io control.
-    pub fn set_int1_io_ctrl(&mut self, int1_io_ctrl: IntIoCtrl) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_int1_io_ctrl(&mut self, int1_io_ctrl: IntIoCtrl) -> Result<(), Error<CommE>> {
         let reg = int1_io_ctrl.to_reg();
         self.iface.write_reg(Registers::INT1_IO_CTRL, reg)?;
         Ok(())
     }
 
     /// Get interrupt 2 io control.
-    pub fn get_int2_io_ctrl(&mut self) -> Result<IntIoCtrl, Error<CommE, CsE>> {
+    pub fn get_int2_io_ctrl(&mut self) -> Result<IntIoCtrl, Error<CommE>> {
         let int2_io_ctrl = self.iface.read_reg(Registers::INT2_IO_CTRL)?;
         Ok(IntIoCtrl::from_reg(int2_io_ctrl))
     }
 
     /// Set interrupt 2 io control.
-    pub fn set_int2_io_ctrl(&mut self, int2_io_ctrl: IntIoCtrl) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_int2_io_ctrl(&mut self, int2_io_ctrl: IntIoCtrl) -> Result<(), Error<CommE>> {
         let reg = int2_io_ctrl.to_reg();
         self.iface.write_reg(Registers::INT2_IO_CTRL, reg)?;
         Ok(())
     }
 
     /// Get interrupt latched mode.
-    pub fn get_int_latch(&mut self) -> Result<IntLatch, Error<CommE, CsE>> {
+    pub fn get_int_latch(&mut self) -> Result<IntLatch, Error<CommE>> {
         let int_latch = self.iface.read_reg(Registers::INT_LATCH)?;
         Ok(IntLatch::from_reg(int_latch))
     }
 
     /// Set interrupt latched mode.
-    pub fn set_int_latch(&mut self, int_latch: IntLatch) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_int_latch(&mut self, int_latch: IntLatch) -> Result<(), Error<CommE>> {
         self.iface
             .write_reg(Registers::INT_LATCH, int_latch as u8)?;
         Ok(())
     }
 
     /// Get interrupt 1 feature mapping.
-    pub fn get_int1_map_feat(&mut self) -> Result<IntMapFeat, Error<CommE, CsE>> {
+    pub fn get_int1_map_feat(&mut self) -> Result<IntMapFeat, Error<CommE>> {
         let int1_map_feat = self.iface.read_reg(Registers::INT1_MAP_FEAT)?;
         Ok(IntMapFeat::from_reg(int1_map_feat))
     }
@@ -429,14 +429,14 @@ where
     pub fn set_int1_map_feat(
         &mut self,
         int1_map_feat: IntMapFeat,
-    ) -> Result<(), Error<CommE, CsE>> {
+    ) -> Result<(), Error<CommE>> {
         let reg = int1_map_feat.to_reg();
         self.iface.write_reg(Registers::INT1_MAP_FEAT, reg)?;
         Ok(())
     }
 
     /// Get interrupt 2 feature mapping.
-    pub fn get_int2_map_feat(&mut self) -> Result<IntMapFeat, Error<CommE, CsE>> {
+    pub fn get_int2_map_feat(&mut self) -> Result<IntMapFeat, Error<CommE>> {
         let int2_map_feat = self.iface.read_reg(Registers::INT2_MAP_FEAT)?;
         Ok(IntMapFeat::from_reg(int2_map_feat))
     }
@@ -445,46 +445,46 @@ where
     pub fn set_int2_map_feat(
         &mut self,
         int2_map_feat: IntMapFeat,
-    ) -> Result<(), Error<CommE, CsE>> {
+    ) -> Result<(), Error<CommE>> {
         let reg = int2_map_feat.to_reg();
         self.iface.write_reg(Registers::INT2_MAP_FEAT, reg)?;
         Ok(())
     }
 
     /// Get interrupt data map.
-    pub fn get_int_map_data(&mut self) -> Result<IntMapData, Error<CommE, CsE>> {
+    pub fn get_int_map_data(&mut self) -> Result<IntMapData, Error<CommE>> {
         let int_map_data = self.iface.read_reg(Registers::INT_MAP_DATA)?;
         Ok(IntMapData::from_reg(int_map_data))
     }
 
     /// Set interrupt data map.
-    pub fn set_int_map_data(&mut self, int_map_data: IntMapData) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_int_map_data(&mut self, int_map_data: IntMapData) -> Result<(), Error<CommE>> {
         let reg = int_map_data.to_reg();
         self.iface.write_reg(Registers::INT_MAP_DATA, reg)?;
         Ok(())
     }
 
     /// Get initialization control register.
-    pub fn get_init_ctrl(&mut self) -> Result<u8, Error<CommE, CsE>> {
+    pub fn get_init_ctrl(&mut self) -> Result<u8, Error<CommE>> {
         let init_ctrl = self.iface.read_reg(Registers::INIT_CTRL)?;
         Ok(init_ctrl)
     }
 
     /// Set initialization control register (start initialization).
-    pub fn set_init_ctrl(&mut self, init_ctrl: u8) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_init_ctrl(&mut self, init_ctrl: u8) -> Result<(), Error<CommE>> {
         self.iface.write_reg(Registers::INIT_CTRL, init_ctrl)?;
         Ok(())
     }
 
     /// Get init address.
-    pub fn get_init_addr(&mut self) -> Result<u16, Error<CommE, CsE>> {
+    pub fn get_init_addr(&mut self) -> Result<u16, Error<CommE>> {
         let mut payload = [Registers::INIT_ADDR_0, 0, 0];
         self.iface.read(&mut payload)?;
         Ok(u16::from(payload[1] & 0b0000_1111) | u16::from(payload[2]) << 4)
     }
 
     /// Set init address.
-    pub fn set_init_addr(&mut self, init_addr: u16) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_init_addr(&mut self, init_addr: u16) -> Result<(), Error<CommE>> {
         let reg_0 = init_addr as u8 & 0b0000_1111;
         let reg_1 = (init_addr >> 4) as u8;
         let mut payload = [Registers::INIT_ADDR_0, reg_0, reg_1];
@@ -493,89 +493,89 @@ where
     }
 
     /// Get the initialization register.
-    pub fn get_init_data(&mut self) -> Result<u8, Error<CommE, CsE>> {
+    pub fn get_init_data(&mut self) -> Result<u8, Error<CommE>> {
         let init_data = self.iface.read_reg(Registers::INIT_DATA)?;
         Ok(init_data)
     }
 
     /// Set the initialization register.
-    pub fn set_init_data(&mut self, init_data: u8) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_init_data(&mut self, init_data: u8) -> Result<(), Error<CommE>> {
         self.iface.write_reg(Registers::INIT_DATA, init_data)?;
         Ok(())
     }
 
     /// Get the internal errors.
-    pub fn get_internal_error(&mut self) -> Result<InternalError, Error<CommE, CsE>> {
+    pub fn get_internal_error(&mut self) -> Result<InternalError, Error<CommE>> {
         let internal_error = self.iface.read_reg(Registers::INTERNAL_ERROR)?;
         Ok(InternalError::from_reg(internal_error))
     }
 
     /// Get ASDA pull up.
-    pub fn get_asda_pullup(&mut self) -> Result<PullUpConf, Error<CommE, CsE>> {
+    pub fn get_asda_pullup(&mut self) -> Result<PullUpConf, Error<CommE>> {
         let aux_if_trim = self.iface.read_reg(Registers::AUX_IF_TRIM)?;
         Ok(PullUpConf::from_reg(aux_if_trim))
     }
 
     /// Set ASDA pull up.
-    pub fn set_asda_pullup(&mut self, pull_up_conf: PullUpConf) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_asda_pullup(&mut self, pull_up_conf: PullUpConf) -> Result<(), Error<CommE>> {
         self.iface
             .write_reg(Registers::AUX_IF_TRIM, pull_up_conf.to_reg())?;
         Ok(())
     }
 
     /// Get gyroscope component retrimming register.
-    pub fn get_gyr_crt_conf(&mut self) -> Result<GyrCrtConf, Error<CommE, CsE>> {
+    pub fn get_gyr_crt_conf(&mut self) -> Result<GyrCrtConf, Error<CommE>> {
         let gyr_crt_conf = self.iface.read_reg(Registers::GYR_CRT_CONF)?;
         Ok(GyrCrtConf::from_reg(gyr_crt_conf))
     }
 
     /// Set gyroscope component retrimming register.
     /// GyrCrtConf.rdy_for_dl is read-only, only crt_running will be set.
-    pub fn set_gyr_crt_conf(&mut self, gyr_crt_conf: GyrCrtConf) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_gyr_crt_conf(&mut self, gyr_crt_conf: GyrCrtConf) -> Result<(), Error<CommE>> {
         self.iface
             .write_reg(Registers::GYR_CRT_CONF, gyr_crt_conf.to_reg())?;
         Ok(())
     }
 
     /// Get NVM configuration.
-    pub fn get_nvm_conf(&mut self) -> Result<bool, Error<CommE, CsE>> {
+    pub fn get_nvm_conf(&mut self) -> Result<bool, Error<CommE>> {
         let nvm_conf = self.iface.read_reg(Registers::NVM_CONF)?;
         Ok((nvm_conf & 1 << 1) != 0)
     }
 
     /// Set NVM configuration.
-    pub fn set_nvm_conf(&mut self, gyr_crt_conf: bool) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_nvm_conf(&mut self, gyr_crt_conf: bool) -> Result<(), Error<CommE>> {
         let value: u8 = if gyr_crt_conf { 0x01 } else { 0x00 };
         self.iface.write_reg(Registers::NVM_CONF, value << 1)?;
         Ok(())
     }
 
     /// Get the interface configuration.
-    pub fn get_if_conf(&mut self) -> Result<IfConf, Error<CommE, CsE>> {
+    pub fn get_if_conf(&mut self) -> Result<IfConf, Error<CommE>> {
         let if_conf = self.iface.read_reg(Registers::IF_CONF)?;
         Ok(IfConf::from_reg(if_conf))
     }
 
     /// Set the interface configuration.
-    pub fn set_if_conf(&mut self, if_conf: IfConf) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_if_conf(&mut self, if_conf: IfConf) -> Result<(), Error<CommE>> {
         self.iface.write_reg(Registers::IF_CONF, if_conf.to_reg())?;
         Ok(())
     }
 
     /// Get the drive strength configuration.
-    pub fn get_drv(&mut self) -> Result<Drv, Error<CommE, CsE>> {
+    pub fn get_drv(&mut self) -> Result<Drv, Error<CommE>> {
         let drv = self.iface.read_reg(Registers::DRV)?;
         Ok(Drv::from_reg(drv))
     }
 
     /// Set the drive strength configuration.
-    pub fn set_drv(&mut self, drv: Drv) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_drv(&mut self, drv: Drv) -> Result<(), Error<CommE>> {
         self.iface.write_reg(Registers::DRV, drv.to_reg())?;
         Ok(())
     }
 
     /// Get the accelerometer self test configuration.
-    pub fn get_acc_self_test(&mut self) -> Result<AccSelfTest, Error<CommE, CsE>> {
+    pub fn get_acc_self_test(&mut self) -> Result<AccSelfTest, Error<CommE>> {
         let acc_self_test = self.iface.read_reg(Registers::ACC_SELF_TEST)?;
         Ok(AccSelfTest::from_reg(acc_self_test))
     }
@@ -584,32 +584,32 @@ where
     pub fn set_acc_self_test(
         &mut self,
         acc_self_test: AccSelfTest,
-    ) -> Result<(), Error<CommE, CsE>> {
+    ) -> Result<(), Error<CommE>> {
         self.iface
             .write_reg(Registers::ACC_SELF_TEST, acc_self_test.to_reg())?;
         Ok(())
     }
 
     /// Get the gyroscope self test configuration.
-    pub fn get_gyr_self_test(&mut self) -> Result<GyrSelfTest, Error<CommE, CsE>> {
+    pub fn get_gyr_self_test(&mut self) -> Result<GyrSelfTest, Error<CommE>> {
         let gyr_self_test = self.iface.read_reg(Registers::GYR_SELF_TEST)?;
         Ok(GyrSelfTest::from_reg(gyr_self_test))
     }
 
     /// Get NV configuration.
-    pub fn get_nv_conf(&mut self) -> Result<NvConf, Error<CommE, CsE>> {
+    pub fn get_nv_conf(&mut self) -> Result<NvConf, Error<CommE>> {
         let nv_conf = self.iface.read_reg(Registers::NV_CONF)?;
         Ok(NvConf::from_reg(nv_conf))
     }
 
     /// Set NV configuration.
-    pub fn set_nv_conf(&mut self, nv_conf: NvConf) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_nv_conf(&mut self, nv_conf: NvConf) -> Result<(), Error<CommE>> {
         self.iface.write_reg(Registers::NV_CONF, nv_conf.to_reg())?;
         Ok(())
     }
 
     /// Get accelerometer offsets.
-    pub fn get_acc_offsets(&mut self) -> Result<AccOffsets, Error<CommE, CsE>> {
+    pub fn get_acc_offsets(&mut self) -> Result<AccOffsets, Error<CommE>> {
         let mut payload = [Registers::OFFSET_0, 0, 0, 0];
         self.iface.read(&mut payload)?;
         Ok(AccOffsets {
@@ -620,7 +620,7 @@ where
     }
 
     /// Set accelerometer offsets.
-    pub fn set_acc_offsets(&mut self, acc_offsets: AccOffsets) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_acc_offsets(&mut self, acc_offsets: AccOffsets) -> Result<(), Error<CommE>> {
         let mut payload = [
             Registers::OFFSET_0,
             acc_offsets.x,
@@ -632,7 +632,7 @@ where
     }
 
     /// Get gyroscope offsets.
-    pub fn get_gyr_offsets(&mut self) -> Result<GyrOffsets, Error<CommE, CsE>> {
+    pub fn get_gyr_offsets(&mut self) -> Result<GyrOffsets, Error<CommE>> {
         let mut payload = [0_u8; 5];
         payload[0] = Registers::OFFSET_3;
         self.iface.read(&mut payload)?;
@@ -653,7 +653,7 @@ where
     }
 
     /// Set gyroscope offsets.
-    pub fn set_gyr_offsets(&mut self, gyr_offsets: GyrOffsets) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_gyr_offsets(&mut self, gyr_offsets: GyrOffsets) -> Result<(), Error<CommE>> {
         let mut payload = [0_u8; 5];
         payload[0] = Registers::OFFSET_3;
 
@@ -672,39 +672,39 @@ where
     }
 
     /// Get power configuration.
-    pub fn get_pwr_conf(&mut self) -> Result<PwrConf, Error<CommE, CsE>> {
+    pub fn get_pwr_conf(&mut self) -> Result<PwrConf, Error<CommE>> {
         let pwr_conf = self.iface.read_reg(Registers::PWR_CONF)?;
         Ok(PwrConf::from_reg(pwr_conf))
     }
 
     /// Set power configuration.
-    pub fn set_pwr_conf(&mut self, pwr_conf: PwrConf) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_pwr_conf(&mut self, pwr_conf: PwrConf) -> Result<(), Error<CommE>> {
         self.iface
             .write_reg(Registers::PWR_CONF, pwr_conf.to_reg())?;
         Ok(())
     }
 
     /// Get power control.
-    pub fn get_pwr_ctrl(&mut self) -> Result<PwrCtrl, Error<CommE, CsE>> {
+    pub fn get_pwr_ctrl(&mut self) -> Result<PwrCtrl, Error<CommE>> {
         let pwr_ctrl = self.iface.read_reg(Registers::PWR_CTRL)?;
         Ok(PwrCtrl::from_reg(pwr_ctrl))
     }
 
     /// Set power control.
-    pub fn set_pwr_ctrl(&mut self, pwr_ctrl: PwrCtrl) -> Result<(), Error<CommE, CsE>> {
+    pub fn set_pwr_ctrl(&mut self, pwr_ctrl: PwrCtrl) -> Result<(), Error<CommE>> {
         self.iface
             .write_reg(Registers::PWR_CTRL, pwr_ctrl.to_reg())?;
         Ok(())
     }
 
     /// Send a command.
-    pub fn send_cmd(&mut self, cmd: Cmd) -> Result<(), Error<CommE, CsE>> {
+    pub fn send_cmd(&mut self, cmd: Cmd) -> Result<(), Error<CommE>> {
         self.iface.write_reg(Registers::CMD, cmd as u8)?;
         Ok(())
     }
 
     /// Initialize sensor.
-    pub fn init(&mut self, config_file: &[u8]) -> Result<(), Error<CommE, CsE>> {
+    pub fn init(&mut self, config_file: &[u8]) -> Result<(), Error<CommE>> {
 
         // Disable advanced power mode
         let mut pwr_conf = self.get_pwr_conf()?;
@@ -731,10 +731,10 @@ where
             };
 
             vec.push(Registers::INIT_DATA)
-                .map_err(|_| Error::<CommE, CsE>::Alloc)?;
+                .map_err(|_| Error::<CommE>::Alloc)?;
 
             vec.push_all(&config_file[offset as usize..end as usize])
-                .map_err(|_| Error::<CommE, CsE>::Alloc)?;
+                .map_err(|_| Error::<CommE>::Alloc)?;
 
             self.iface.write(&mut vec.as_mut_slice())?;
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,38 +1,36 @@
 use crate::types::Error;
-use embedded_hal::blocking::{i2c, spi};
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::i2c::{I2c, SevenBitAddress};
+use embedded_hal::spi::SpiDevice;
 
+/// Default I2C address of BMI270
 const BMI270_I2C_ADDR: u8 = 0x68;
+/// Alternative I2C address when SDO is pulled high
+const BMI270_I2C_ADDR_ALT: u8 = 0x69;
 
 pub struct I2cInterface<I2C> {
     pub i2c: I2C,
     pub address: u8,
 }
 
-pub struct SpiInterface<SPI, CS> {
+pub struct SpiInterface<SPI> {
     pub spi: SPI,
-    pub cs: CS,
 }
 
 /// I2c address.
+#[derive(Debug, Default, Clone, Copy)]
 pub enum I2cAddr {
     /// Use the default i2c address, 0x68.
+    #[default]
     Default,
-    /// Use alternative 0x69 as the i2c address. (selected when SDO is pulled high).
+    /// Use alternative 0x69 as the i2c address (selected when SDO is pulled high).
     Alternative,
 }
 
-impl Default for I2cAddr {
-    fn default() -> Self {
-        I2cAddr::Default
-    }
-}
-
 impl I2cAddr {
-    pub fn addr(self) -> u8 {
+    pub fn addr(self) -> SevenBitAddress {
         match self {
             I2cAddr::Default => BMI270_I2C_ADDR,
-            I2cAddr::Alternative => BMI270_I2C_ADDR | 1,
+            I2cAddr::Alternative => BMI270_I2C_ADDR_ALT,
         }
     }
 }
@@ -51,9 +49,9 @@ pub trait ReadData {
 
 impl<I2C, E> WriteData for I2cInterface<I2C>
 where
-    I2C: i2c::Write<Error = E>,
+    I2C: I2c<Error = E>,
 {
-    type Error = Error<E, ()>;
+    type Error = Error<I2C::Error>;
     fn write(&mut self, payload: &mut [u8]) -> Result<(), Self::Error> {
         self.i2c
             .write(self.address, payload)
@@ -68,18 +66,16 @@ where
     }
 }
 
-impl<SPI, CS, CommE, CsE> WriteData for SpiInterface<SPI, CS>
+impl<SPI, CommE> WriteData for SpiInterface<SPI>
 where
-    SPI: spi::Write<u8, Error = CommE>,
-    CS: OutputPin<Error = CsE>,
+    SPI: SpiDevice<Error = CommE>,
 {
-    type Error = Error<CommE, CsE>;
+    type Error = Error<CommE>;
     fn write(&mut self, payload: &mut [u8]) -> Result<(), Self::Error> {
         payload[0] += 0x80;
 
-        self.cs.set_low().map_err(Error::Cs)?;
+        // `write` asserts and deasserts CS for us. No need to do it manually!
         let res = self.spi.write(&payload).map_err(Error::Comm);
-        self.cs.set_high().map_err(Error::Cs)?;
 
         res
     }
@@ -87,9 +83,8 @@ where
     fn write_reg(&mut self, register: u8, data: u8) -> Result<(), Self::Error> {
         let payload: [u8; 2] = [register + 0x80, data];
 
-        self.cs.set_low().map_err(Error::Cs)?;
+        // `write` asserts and deasserts CS for us. No need to do it manually!
         let res = self.spi.write(&payload).map_err(Error::Comm);
-        self.cs.set_high().map_err(Error::Cs)?;
 
         res
     }
@@ -97,9 +92,9 @@ where
 
 impl<I2C, E> ReadData for I2cInterface<I2C>
 where
-    I2C: i2c::WriteRead<Error = E>,
+    I2C: I2c<Error = E>,
 {
-    type Error = Error<E, ()>;
+    type Error = Error<I2C::Error>;
     fn read(&mut self, payload: &mut [u8]) -> Result<(), Self::Error> {
         self.i2c
             .write_read(self.address, &[payload[0]], &mut payload[1..])
@@ -115,16 +110,14 @@ where
     }
 }
 
-impl<SPI, CS, CommE, CsE> ReadData for SpiInterface<SPI, CS>
+impl<SPI, CommE> ReadData for SpiInterface<SPI>
 where
-    SPI: spi::Transfer<u8, Error = CommE>,
-    CS: OutputPin<Error = CsE>,
+    SPI: SpiDevice<Error = CommE>,
 {
-    type Error = Error<CommE, CsE>;
+    type Error = Error<CommE>;
     fn read(&mut self, payload: &mut [u8]) -> Result<(), Self::Error> {
-        self.cs.set_low().map_err(Error::Cs)?;
-        let res = self.spi.transfer(payload).map_err(Error::Comm);
-        self.cs.set_high().map_err(Error::Cs)?;
+        // `read` asserts and deasserts CS for us. No need to do it manually!
+        let res = self.spi.read(payload).map_err(Error::Comm);
 
         res?;
         Ok(())
@@ -133,10 +126,12 @@ where
     fn read_reg(&mut self, register: u8) -> Result<u8, Self::Error> {
         let mut payload = [register, 0];
 
-        self.cs.set_low().map_err(Error::Cs)?;
-        let res = self.spi.transfer(&mut payload).map_err(Error::Comm);
-        self.cs.set_high().map_err(Error::Cs)?;
+        // `read` asserts and deasserts CS for us. No need to do it manually!
+        let res = self.spi.read(&mut payload).map_err(Error::Comm);
 
-        Ok(res?[1])
+        match res {
+                Ok(_) => Ok(payload[1]),
+                Err(e) => Err(e)
+        }   
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,10 +1,8 @@
 /// The possible errors that could be encountered.
 #[derive(Debug)]
-pub enum Error<CommE, CsE> {
+pub enum Error<CommE> {
     /// Communication error over I2C or SPI.
     Comm(CommE),
-    /// Pin error on the SPI chip select.
-    Cs(CsE),
     /// Memory allocation error during initialization.
     Alloc,
 }


### PR DESCRIPTION
This upgrades e-hal to 1.0.0

The main change is, that the CS pin is managed automatically by the SpiDevice: https://docs.rs/embedded-hal/latest/embedded_hal/spi/index.html

I was only able to test the I2C implementation, as I don't have hardware that uses SPI to connect to the sensor.