### PR TITLE
Make mod types pub

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,18 +4,11 @@
 extern crate fixedvec;
 
 mod registers;
-mod types;
 pub mod config;
 
 pub mod interface;
 pub use interface::I2cAddr;
-pub use types::{
-    AccConf, AccOffsets, AccRange, AccSelfTest, AuxConf, AuxData, AuxIfConf, AxisData, Burst, Cmd,
-    Data, Drv, Error, ErrorReg, ErrorRegMsk, Event, FifoConf, FifoDowns, GyrConf, GyrCrtConf,
-    GyrOffsets, GyrRange, GyrSelfTest, IfConf, IntIoCtrl, IntLatch, IntMapData, IntMapFeat,
-    InternalError, InternalStatus, InterruptStatus, MapData, NvConf, OutputBehavior, OutputLevel, 
-    PullUpConf, PwrConf, PwrCtrl, Saturation, Status, WristGestureActivity, FIFO_LENGTH_1_MASK,
-};
+pub mod types;
 
 pub mod bmi270;
 pub use bmi270::Bmi270;

--- a/src/types.rs
+++ b/src/types.rs
@@ -44,7 +44,7 @@ impl ErrRegMask {
 pub struct ErrorReg {
     /// The chip is not in an operational state.
     pub fatal_err: bool,
-    /// Interal error (Bosch advises to contact the Sensortec support).
+    /// Internal error (Bosch advises to contact the Sensortec support).
     pub internal_err: u8,
     /// Error when a frame is reaad in streaming mode and the fifo is overfilled.
     pub fifo_err: bool,


### PR DESCRIPTION
This make the types mod public.

I don't see any type in the types mod that should not be public, but if desired, I can set any of the types to `pub(crate)`, but I think it makes sense for all of them to be `pub`. 