### PR TITLE
WIP: Add basic read example for ESP32-based systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/qrasmont/bmi2"
 readme = "README.md"
 keywords = ["bmi2", "bmi270", "bmi260", "embedded-hal", "imu"]
 
-exclude = ["examples/nrf52840/.cargo"]
+exclude = ["examples/nrf52840/.cargo", "examples/esp32/.cargo"]
 
 [dependencies]
 embedded-hal = "1.0.0"

--- a/examples/esp32/basic_read/.cargo/config.toml
+++ b/examples/esp32/basic_read/.cargo/config.toml
@@ -1,0 +1,21 @@
+[build]
+target = "xtensa-esp32s3-espidf"
+rustflags = [
+  "-C", "link-arg=-Tlinkall.x",
+  "-C", "link-arg=-Tdefmt.x",
+  # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
+  # NOTE: May negatively impact performance of produced code
+  "-C", "force-frame-pointers",
+]
+
+[target.xtensa-esp32s3-espidf]
+runner = "espflash flash --monitor --log-format defmt " # --port /dev/cu.usbserial-0001
+
+[unstable]
+build-std = ["core", "alloc"]
+
+[env]
+MCU = "esp32s3"
+
+DEFMT_LOG = "trace"
+DEFMT_TIME_FORMAT = "{=u64:us}"

--- a/examples/esp32/basic_read/Cargo.toml
+++ b/examples/esp32/basic_read/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "basic-read-esp32"
+edition = "2021"
+publish = false
+
+[dependencies]
+defmt = "0.3.10"
+embedded-hal = { version = "1.0.0" }
+embedded-hal-bus = {version = "0.3.0", features = ["defmt-03"]}
+embassy-embedded-hal = { version = "0.3.0", features = ["defmt"] }
+embassy-executor = { version = "0.7.0", features = ["defmt", "task-arena-size-16384"] }
+embassy-sync = "0.6.2"
+embassy-time = { version = "0.4.0", features = ["generic-queue-64"] }
+esp-hal = { version = "1.0.0-beta.0", features = ["esp32s3", "defmt", "unstable"] }
+esp-hal-embassy = { version = "0.7.0", features = ["esp32s3"] }
+esp-println = { version = "0.13.1", features = ["esp32s3", "defmt-espflash"] }
+static_cell = "2.1.0"
+
+bmi2 = { path = "../../../" }
+
+[profile.release]
+debug = 2
+
+[build-dependencies]
+embuild = "0.33"

--- a/examples/esp32/basic_read/rust-toolchain.toml
+++ b/examples/esp32/basic_read/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "esp"

--- a/examples/esp32/basic_read/src/main.rs
+++ b/examples/esp32/basic_read/src/main.rs
@@ -1,0 +1,94 @@
+//! This example runs on the ESP32-S3-DevKitC-1 board, wired to a BMI270 via SPI
+//! It demonstrates simple IMU data read functionality.
+#![no_std]
+#![no_main]
+
+use bmi2::config;
+use bmi2::types::Burst;
+use bmi2::types::PwrCtrl;
+use bmi2::Bmi2;
+
+use embassy_executor::Spawner;
+use embassy_time::Delay;
+use embedded_hal::delay::DelayNs;
+use embedded_hal_bus::spi::ExclusiveDevice;
+use esp_hal::gpio::{Level, Output, OutputConfig};
+use esp_hal::spi::{master::Config, Mode};
+use esp_hal::time::Rate;
+use esp_hal::{clock::CpuClock, timer::timg::TimerGroup};
+use esp_println as _;
+
+#[esp_hal_embassy::main]
+async fn main(_spawner: Spawner) {
+    // Set up ESP32
+    let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
+    let timer_group = TimerGroup::new(peripherals.TIMG0);
+
+    esp_hal_embassy::init(timer_group.timer1);
+
+    // Initialize SPI
+    let cs = Output::new(peripherals.GPIO3, Level::High, OutputConfig::default());
+    let sclk = peripherals.GPIO8;
+    let mosi = peripherals.GPIO2;
+    let miso = peripherals.GPIO1;
+
+    let spi_bus = esp_hal::spi::master::Spi::new(
+        peripherals.SPI2,
+        Config::default()
+            .with_frequency(Rate::from_khz(100))
+            .with_mode(Mode::_0),
+    )
+    .unwrap()
+    .with_sck(sclk)
+    .with_mosi(mosi)
+    .with_miso(miso);
+
+    // Create the SPI device with CS pin management
+    let spi_device = ExclusiveDevice::new_no_delay(spi_bus, cs).unwrap();
+
+    const BUFFER_SIZE: usize = 256;
+
+    let mut bmi = Bmi2::<_, _, BUFFER_SIZE>::new_spi(spi_device, Delay, Burst::new(255));
+
+    let chip_id = match bmi.get_chip_id() {
+        Ok(0) => defmt::panic!("Chip ID is 0, which is invalid"),
+        Ok(id) => id,
+        Err(_) => defmt::panic!("Failed to get chip ID"),
+    };
+
+    defmt::info!("chip id: {}", chip_id);
+
+    bmi.init(&config::BMI270_CONFIG_FILE).unwrap();
+
+    // Enable power for the accelerometer and the gyroscope.
+    let pwr_ctrl = PwrCtrl {
+        aux_en: false,
+        gyr_en: true,
+        acc_en: true,
+        temp_en: false,
+    };
+    bmi.set_pwr_ctrl(pwr_ctrl).unwrap();
+
+    let mut delay = esp_hal::delay::Delay::new();
+
+    loop {
+        let data = bmi.get_data().unwrap();
+        defmt::info!(
+            "data: acc_x:{}, acc_y:{}, acc_z:{}, gyr_x:{}, gyr_y:{}, gyr_z:{}",
+            data.acc.x,
+            data.acc.y,
+            data.acc.z,
+            data.gyr.x,
+            data.gyr.y,
+            data.gyr.z
+        );
+        delay.delay_ms(500);
+    }
+}
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    defmt::info!("Panic: {}", info);
+
+    loop {}
+}


### PR DESCRIPTION
**Note: this code panics!**

This is an attempt to add a basic read example for ESP32 systems (implemented on an [ESP32S3 dev board](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32s3/esp32-s3-devkitc-1/index.html) by Espressif).

I have the [Adafruit BMI270](https://www.sparkfun.com/sparkfun-6dof-imu-breakout-bmi270-qwiic.html) board with the following wiring:
```
SDA -> GPIO2
SCL -> GPIO8
ADR -> GPIO1
CS  -> GPIO3
```

However for some reason when running my code, I get the following output:

```
I (179) boot: Loaded app from partition at offset 0x10000
I (180) boot: Disabling RNG early entropy source...
DEBUG Reset Spi2
DEBUG Enable Spi2 false
DEBUG Reset Spi3
DEBUG Enable Spi3 false
DEBUG Reset I2cExt0
DEBUG Enable I2cExt0 false
DEBUG Reset I2cExt1
DEBUG Enable I2cExt1 false
DEBUG Reset Rmt
DEBUG Enable Rmt false
DEBUG Reset Ledc
DEBUG Enable Ledc false
DEBUG Reset Mcpwm0
DEBUG Enable Mcpwm0 false
DEBUG Reset Mcpwm1
DEBUG Enable Mcpwm1 false
DEBUG Reset Pcnt
DEBUG Enable Pcnt false
DEBUG Reset ApbSarAdc
DEBUG Enable ApbSarAdc false
DEBUG Reset Gdma
DEBUG Enable Gdma false
DEBUG Reset I2s0
DEBUG Enable I2s0 false
DEBUG Reset I2s1
DEBUG Enable I2s1 false
DEBUG Reset Usb
DEBUG Enable Usb false
DEBUG Reset Aes
DEBUG Enable Aes false
DEBUG Reset Twai0
DEBUG Enable Twai0 false
DEBUG Reset Timg1
DEBUG Enable Timg1 false
DEBUG Reset Sha
DEBUG Enable Sha false
DEBUG Reset Uart1
DEBUG Enable Uart1 false
DEBUG Reset Uart2
DEBUG Enable Uart2 false
DEBUG Reset Rsa
DEBUG Enable Rsa false
DEBUG Reset Hmac
DEBUG Enable Hmac false
DEBUG Reset LcdCam
DEBUG Enable LcdCam false
TRACE Enable Timg0 0 -> 1
DEBUG Enable Timg0 true
TRACE Enable Spi2 0 -> 1
DEBUG Enable Spi2 true
DEBUG Reset Spi2
ERROR panicked at 'Chip ID is 0, which is invalid'
```

I'm not sure what would cause chip ID to read as 0, but the rest of the code _seems_ correct, so as long as we can fix that, we can merge this.