### PR TITLE
Add support to aux device.

### DIFF
--- a/src/bmi2.rs
+++ b/src/bmi2.rs
@@ -727,6 +727,28 @@ where
         Ok(())
     }
 
+    /// Write auxiliary data to the sensor.
+    pub fn aux_read_reg(
+        &mut self,
+        reg_addr: u8,
+    ) -> Result<u8, Error<CommE>> {
+        self.iface.write_reg(Registers::AUX_RD_ADDR, reg_addr)?;
+        while self.get_status()?.aux_dev_busy {
+            self.delay.delay_us(10);
+        }
+        let r = self.iface.read_reg(Registers::AUX_DATA_0)?;
+        Ok(r)
+    }
+
+
+    pub fn write_aux_data( &mut self, reg_addr: u8, reg_data: u8) -> Result<(), Error<CommE>> {
+        self.iface.write_reg(Registers::AUX_WR_DATA, reg_data)?;
+        while self.get_status()?.aux_dev_busy {
+            self.delay.delay_us(10);
+        }
+        self.iface.write_reg(Registers::AUX_WR_ADDR, reg_addr)?;
+        Ok(())
+    }
 
     /// Initialize sensor.
     pub fn init(&mut self, config_file: &[u8]) -> Result<(), Error<CommE>> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1359,6 +1359,7 @@ impl IfConfMask {
 
 /// SPI interface mode.
 #[repr(u8)]
+#[derive(Debug, Clone, Copy)]
 pub enum SpiMode {
     /// SPI 4-wire mode.
     Spi4 = 0x00,
@@ -1391,8 +1392,8 @@ impl IfConf {
                 0x01 => SpiMode::Spi3,
                 _ => panic!(), // TODO
             },
-            ois_en: (reg & IfConfMask::OIS_EN) >> 2 != 0,
-            aux_en: (reg & IfConfMask::AUX_EN) >> 3 != 0,
+            ois_en: (reg & IfConfMask::OIS_EN) >> 4 != 0,
+            aux_en: (reg & IfConfMask::AUX_EN) >> 5 != 0,
         }
     }
 
@@ -1402,7 +1403,7 @@ impl IfConf {
         let ois_en = if self.ois_en { 0x01 } else { 0x00 };
         let aux_en = if self.aux_en { 0x01 } else { 0x00 };
 
-        spi_mode | spi_mode_ois << 1 | ois_en << 2 | aux_en << 3
+        spi_mode | spi_mode_ois << 1 | ois_en << 4 | aux_en << 5
     }
 }
 


### PR DESCRIPTION
Add aux device support to Bmi2 struct, fix if_conf bit calculation  mistake.

1. Aux support: add `aux_read_reg` and `write_aux_data` fn
2. if_conf reg's definition see bellow:

<img width="957" alt="Screenshot 2025-06-18 at 9 30 12 PM" src="https://github.com/user-attachments/assets/77c38abb-2e1d-4485-af00-06d24b7b12a1" />
